### PR TITLE
Fixed an error when building docker images on MacOS

### DIFF
--- a/contrib/docker/make-dimage.sh
+++ b/contrib/docker/make-dimage.sh
@@ -45,7 +45,7 @@ fi
 CONTEXT='.'
 
 DIMAGE_NAME="${DOCKER_IMAGE_NAME}"
-DIMAGE_VERSION=`date -Iseconds | sed -e 's/:/-/g'`
+DIMAGE_VERSION=`date "+%Y-%m-%dT%H:%M:%S%z" | sed -e 's/:/-/g'`
 
 DIMAGE_ID="${DIMAGE_NAME}:${DIMAGE_VERSION}"
 

--- a/contrib/docker/make_docker_image.sh
+++ b/contrib/docker/make_docker_image.sh
@@ -40,7 +40,7 @@ fi
 
 DFILE="Dockerfile.he-transformer"
 DIMAGE_NAME="${DOCKER_IMAGE_NAME}"
-DIMAGE_VERSION=`date -Iseconds | sed -e 's/:/-/g'`
+DIMAGE_VERSION=`date "+%Y-%m-%dT%H:%M:%S%z" | sed -e 's/:/-/g'`
 
 DIMAGE_ID="${DIMAGE_NAME}:${DIMAGE_VERSION}"
 


### PR DESCRIPTION
If you would try to build docker images on Mac using "make shell" command, you would get the following error message:
date: illegal option -- I

Solution:
I have replaced `date -Iseconds` with `date "+%Y-%m-%dT%H:%M:%S%z"` which would give the same output, but it is cross compatible