### PR TITLE
Fixes issue related to bfloat in numpy

### DIFF
--- a/cmake/ngraph-tf-bfloat.patch
+++ b/cmake/ngraph-tf-bfloat.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/build_utils.py b/tools/build_utils.py
+index 8aab3a43..bb561d24 100755
+--- a/tools/build_utils.py
++++ b/tools/build_utils.py
+@@ -152,7 +152,7 @@ def setup_venv(venv_dir):
+         "setuptools",
+         "psutil",
+         "six>=1.10.0",
+-        "numpy>=1.13.3",
++        "numpy>=1.16.0,<1.19.0",
+         "absl-py>=0.1.6",
+         "astor>=0.6.0",
+         "google_pasta>=0.1.1",

--- a/cmake/ngraph-tf.cmake
+++ b/cmake/ngraph-tf.cmake
@@ -22,6 +22,7 @@ set(NGRAPH_TF_CMAKE_PREFIX ext_ngraph_tf)
 set(NGRAPH_TF_REPO_URL https://github.com/tensorflow/ngraph-bridge.git)
 set(NGRAPH_TF_GIT_LABEL v0.22.0-rc3)
 set(NGRAPH_TF_PATCH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ngraph-tf.patch)
+set(NGRAPH_TF_PATCH2 ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ngraph-tf-bfloat.patch)
 
 set(NGRAPH_TF_SRC_DIR
     ${CMAKE_BINARY_DIR}/${NGRAPH_TF_CMAKE_PREFIX}/src/${NGRAPH_TF_CMAKE_PREFIX})
@@ -49,6 +50,7 @@ ExternalProject_Add(ext_ngraph_tf
       BUILD_IN_SOURCE 1
       BUILD_BYPRODUCTS ${NGRAPH_TF_CMAKE_PREFIX}
       PATCH_COMMAND git apply ${NGRAPH_TF_PATCH}
+      COMMAND git apply ${NGRAPH_TF_PATCH2}
       BUILD_COMMAND python3 ${NGRAPH_TF_SRC_DIR}/build_ngtf.py --use_grappler_optimizer --ngraph_src_dir ${NGRAPH_SRC_DIR}
       INSTALL_COMMAND ln -fs ${NGRAPH_TF_VENV_DIR}
                       ${EXTERNAL_INSTALL_DIR}


### PR DESCRIPTION
The added patch solves the issue *C++ compilation of rule '//tensorflow/python:bfloat16_lib' failed* by fixing the numpy version to `numpy<1.19.0` as suggested in [this post](https://github.com/tensorflow/tensorflow/issues/40688#issuecomment-647846011) of the tensorflow issue tracker.