### PR TITLE
Configuration changes to build docker containers

### DIFF
--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -61,7 +61,7 @@ make check_clang
 
 ```
 cd contrib/docker
-make check_gcc OS=ubuntu1804
+make check_gcc OS_ID=ubuntu1804
 ```
 
 * To build an Ubuntu 16.04 docker container with persistent builds, compile with gcc 7.4, and run unit tests:

--- a/contrib/docker/make-dimage.sh
+++ b/contrib/docker/make-dimage.sh
@@ -44,8 +44,11 @@ fi
 
 CONTEXT='.'
 
+# A docker tag name must be valid ASCII and may contain lowercase and uppercase letters, 
+# digits, underscores, periods and dashes. A tag name may not start with a period 
+# or a dash and may contain a maximum of 128 characters.
 DIMAGE_NAME="${DOCKER_IMAGE_NAME}"
-DIMAGE_VERSION=`date -Iseconds | sed -e 's/:/-/g'`
+DIMAGE_VERSION=`date -Iseconds | sed -e 's/:/-/g' | sed -e 's/+/-/g'`
 
 DIMAGE_ID="${DIMAGE_NAME}:${DIMAGE_VERSION}"
 


### PR DESCRIPTION
The parameter OS in Makefile changed to OS_ID but it was not updated in README.md. A docker tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters. However, there was a '+' sign in the date string used for the docker tag name, which I replaced with dash.
