### PR TITLE
Ubuntu1804 docker gcc8

### DIFF
--- a/contrib/docker/Dockerfile.he_transformer.ubuntu1804
+++ b/contrib/docker/Dockerfile.he_transformer.ubuntu1804
@@ -22,6 +22,9 @@
 
 FROM ubuntu:18.04
 
+# tzdata - do not run any interactive dialog
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
         python3-pip virtualenv \
         python3-numpy python3-dev python3-wheel \
@@ -36,6 +39,25 @@ RUN apt-get update && apt-get install -y \
         autoconf libtool \
         doxygen graphviz \
         yapf3 python3-yapf
+        
+# install gcc-8
+RUN         apt-get update \
+                && apt-get install -y \
+                    software-properties-common \
+                    wget \
+                && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+                && apt-get update \
+                && apt-get install -y \
+                    make \
+                    git \
+                    curl \
+                    vim \
+                    vim-gnome \
+                    cmake \
+                && apt-get install -y \
+                    gcc-8 g++-8 gcc-8-base \
+                && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+                && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
 
 # Install clang-9
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/contrib/docker/Dockerfile.he_transformer.ubuntu1804
+++ b/contrib/docker/Dockerfile.he_transformer.ubuntu1804
@@ -32,9 +32,8 @@ RUN apt-get update && apt-get install -y \
         unzip wget \
         sudo \
         bash-completion \
-        build-essential cmake \
+        build-essential make cmake \
         software-properties-common \
-        git \
         wget patch diffutils libtinfo-dev \
         autoconf libtool \
         doxygen graphviz \
@@ -44,16 +43,11 @@ RUN apt-get update && apt-get install -y \
 RUN         apt-get update \
                 && apt-get install -y \
                     software-properties-common \
-                    wget \
                 && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
                 && apt-get update \
                 && apt-get install -y \
-                    make \
-                    git \
-                    curl \
                     vim \
                     vim-gnome \
-                    cmake \
                 && apt-get install -y \
                     gcc-8 g++-8 gcc-8-base \
                 && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \


### PR DESCRIPTION
ABY needs gcc >= 8. Update gcc to version 8.0. Do not run any interactive mode. Remove repeated packages. See also issue: https://github.com/IntelAI/he-transformer/issues/51