### PR TITLE
Enable setting the port on the server

### DIFF
--- a/examples/MNIST/README.md
+++ b/examples/MNIST/README.md
@@ -69,13 +69,15 @@ To test the client-server model, in one terminal call
 python test.py --backend=HE_SEAL \
                --model_file=models/cryptonets.pb \
                --enable_client=true \
-               --encryption_parameters=$HE_TRANSFORMER/configs/he_seal_ckks_config_N13_L8.json
+               --encryption_parameters=$HE_TRANSFORMER/configs/he_seal_ckks_config_N13_L8.json \
+               --port 35000
 ```
 
 In another terminal (with the python environment active), call
 ```bash
 python pyclient_mnist.py --batch_size=1024 \
-                         --encrypt_data_str=encrypt
+                         --encrypt_data_str=encrypt \
+                         --port 35000
 ```
 
 ### Multi-party computation with garbled circuits (GC)

--- a/examples/MNIST/mnist_util.py
+++ b/examples/MNIST/mnist_util.py
@@ -235,6 +235,12 @@ def server_argument_parser():
         default="import/output/BiasAdd:0",
         help="Tensor name of model output",
     )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=34000,
+        help="Port number for the server",
+    )
 
     return parser
 
@@ -258,6 +264,7 @@ def server_config_from_flags(FLAGS, tensor_param_name):
         FLAGS.mask_gc_outputs)).encode()
     server_config.parameter_map["num_gc_threads"].s = (str(
         FLAGS.num_gc_threads)).encode()
+    server_config.parameter_map["port"].s = (str(FLAGS.port)).encode()
 
     if FLAGS.enable_client:
         server_config.parameter_map[tensor_param_name].s = b"client_input"

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ For a simple demonstration of a server-client approach, run
 python $HE_TRANSFORMER/examples/ax.py \
   --backend=HE_SEAL \
   --enable_client=yes \
-  --port 350000
+  --port 35000
 ```
 
 This will discard the Tensorflow inputs and instead wait for a client to connect and provide encrypted inputs.

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,13 +32,14 @@ For a simple demonstration of a server-client approach, run
 ```bash
 python $HE_TRANSFORMER/examples/ax.py \
   --backend=HE_SEAL \
-  --enable_client=yes
+  --enable_client=yes \
+  --port 350000
 ```
 
 This will discard the Tensorflow inputs and instead wait for a client to connect and provide encrypted inputs.
 To start the client, in a separate terminal on the same host (with the ngraph-tf bridge python environment active), run
 ```bash
-python $HE_TRANSFORMER/examples/pyclient.py
+python $HE_TRANSFORMER/examples/pyclient.py --port 35000
 ```
 
 Once the computation is complete, the output will be returned to the client and decrypted. The server will attempt decrypt the output as well; however, since it does not have the client's secret key, the output will be meaningless.

--- a/examples/ax.py
+++ b/examples/ax.py
@@ -65,13 +65,17 @@ def main(FLAGS):
     c = tf.compat.v1.placeholder(tf.float32, shape=(1, 4))
     f = c * (a + b)
 
-    # Create config to load parameter b from client
-    config = server_config_from_flags(FLAGS, b.name)
-    print("config", config)
+    try:
+        while True:
+            # Create config to load parameter b from client
+            config = server_config_from_flags(FLAGS, b.name)
+            print("config", config)
 
-    with tf.compat.v1.Session(config=config) as sess:
-        f_val = sess.run(f, feed_dict={b: np.ones((1, 4)), c: np.ones((1, 4))})
-        print("Result: ", f_val)
+            with tf.compat.v1.Session(config=config) as sess:
+                f_val = sess.run(f, feed_dict={b: np.ones((1, 4)), c: np.ones((1, 4))})
+                print("Result: ", f_val)
+    except KeyboardInterrupt:
+        print("Stopping the server.")
 
 
 if __name__ == "__main__":

--- a/examples/ax.py
+++ b/examples/ax.py
@@ -44,6 +44,7 @@ def server_config_from_flags(FLAGS, tensor_param_name):
         "encryption_parameters"].s = FLAGS.encryption_parameters.encode()
     server_config.parameter_map["enable_client"].s = (str(
         FLAGS.enable_client)).encode()
+    server_config.parameter_map["port"].s = (str(FLAGS.port)).encode()
     if FLAGS.enable_client:
         server_config.parameter_map[tensor_param_name].s = b"client_input"
 
@@ -75,7 +76,11 @@ def main(FLAGS):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--batch_size", type=int, default=1, help="Batch size")
+    parser.add_argument(
+        "--batch_size", 
+        type=int, 
+        default=1, 
+        help="Batch size")
     parser.add_argument(
         "--enable_client",
         type=str2bool,
@@ -89,6 +94,12 @@ if __name__ == "__main__":
         default="",
         help=
         "Filename containing json description of encryption parameters, or json description itself",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=34000,
+        help="Port number for the server",
     )
 
     FLAGS, unparsed = parser.parse_known_args()

--- a/examples/pyclient.py
+++ b/examples/pyclient.py
@@ -22,10 +22,9 @@ import argparse
 def main(FLAGS):
     data = (2, 4, 6, 8)
 
-    port = 34000
     batch_size = 1
 
-    client = pyhe_client.HESealClient(FLAGS.hostname, port, batch_size, {
+    client = pyhe_client.HESealClient(FLAGS.hostname, FLAGS.port, batch_size, {
         "client_parameter_name": ("encrypt", data)
     })
 
@@ -36,7 +35,16 @@ def main(FLAGS):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--hostname", type=str, default="localhost", help="Hostname of server")
+        "--hostname", 
+        type=str, 
+        default="localhost", 
+        help="Hostname of server")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=34000,
+        help="Port number of server",
+    )
 
     FLAGS, unparsed = parser.parse_known_args()
 

--- a/src/seal/he_seal_backend.cpp
+++ b/src/seal/he_seal_backend.cpp
@@ -117,6 +117,9 @@ bool HESealBackend::set_config(const std::map<std::string, std::string>& config,
       } else {
         NGRAPH_HE_LOG(3) << "Not masking garbled circuits outputs from config";
       }
+    } else if (option == "port") {
+      m_port = flag_to_int(setting.c_str(), 34000);
+      NGRAPH_HE_LOG(3) << "Setting " << m_port << " port number";
     } else {
       std::string lower_option = to_lower(option);
       std::vector<std::string> lower_settings = split(to_lower(setting), ',');

--- a/src/seal/he_seal_backend.cpp
+++ b/src/seal/he_seal_backend.cpp
@@ -83,6 +83,7 @@ bool HESealBackend::set_config(const std::map<std::string, std::string>& config,
   (void)error;  // Avoid unused parameter warning
   NGRAPH_HE_LOG(3) << "Setting config";
   for (const auto& [option, setting] : config) {
+    NGRAPH_HE_LOG(3) << "option name: <" << option << ">";
     // Check whether client is enabled
     if (option == "enable_client") {
       bool client_enabled = string_to_bool(setting, false);
@@ -131,6 +132,7 @@ bool HESealBackend::set_config(const std::map<std::string, std::string>& config,
 
       static std::unordered_set<std::string> valid_config_settings{
           "client_input", "encrypt", "packed", ""};
+
       for (const auto& lower_setting : lower_settings) {
         NGRAPH_CHECK(valid_config_settings.find(lower_setting) !=
                          valid_config_settings.end(),

--- a/src/seal/he_seal_backend.hpp
+++ b/src/seal/he_seal_backend.hpp
@@ -268,6 +268,11 @@ class HESealBackend : public runtime::Backend {
     return m_num_garbled_circuit_threads;
   }
 
+  /// \brief Returns the port number used for the server
+  size_t port() const {
+    return m_port;
+  }
+
   /// \brief Returns whether or not the garbled circuit inputs should be masked
   /// for privacy
   bool mask_gc_inputs() const { return m_mask_gc_inputs; }
@@ -328,6 +333,7 @@ class HESealBackend : public runtime::Backend {
   bool m_mask_gc_inputs{false};
   bool m_mask_gc_outputs{false};
   size_t m_num_garbled_circuit_threads{1};
+  size_t m_port{34000};
 
   bool m_lazy_mod{string_to_bool(std::getenv("LAZY_MOD"), false)};
 

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -93,7 +93,7 @@ HESealExecutable::HESealExecutable(const std::shared_ptr<Function>& function,
   (void)enable_performance_collection;  // Avoid unused parameter warning
 
   m_context = he_seal_backend.get_context();
-  m_port = he_seal_backend.port()
+  m_port = he_seal_backend.port();
   m_function = function;
 
   if (!m_context->using_keyswitching()) {

--- a/src/seal/he_seal_executable.cpp
+++ b/src/seal/he_seal_executable.cpp
@@ -88,11 +88,12 @@ namespace ngraph::runtime::he {
 HESealExecutable::HESealExecutable(const std::shared_ptr<Function>& function,
                                    bool enable_performance_collection,
                                    HESealBackend& he_seal_backend)
-    : m_he_seal_backend(he_seal_backend), m_batch_size{1}, m_port{34000} {
+    : m_he_seal_backend(he_seal_backend), m_batch_size{1} {
   // TODO(fboemer): Use
   (void)enable_performance_collection;  // Avoid unused parameter warning
 
   m_context = he_seal_backend.get_context();
+  m_port = he_seal_backend.port()
   m_function = function;
 
   if (!m_context->using_keyswitching()) {


### PR DESCRIPTION
Added the port argument for the server. The examples have been updated to be able to specify the port for the client and the server. The main changes in the C++ code were for the he_seal_backend and he_seal_executable.